### PR TITLE
Update segment-control deprecation message

### DIFF
--- a/rules.js
+++ b/rules.js
@@ -9,7 +9,7 @@ const componentsMap = {
   field: "use Warp form components instead",
   card: "use Warp card component instead",
   input: "use Warp input component instead",
-  segment: "use Warp toggle component instead",
+  segment: "use Warp button-group component instead",
   expandable: "use Warp expandable component instead",
   modal: "use Warp modal component instead",
   slider: "use Warp slider component instead",


### PR DESCRIPTION
### Description
Toggle component will no longer be used to render elements with "segment-control" styling. It will be the role of button group component.

### Note
We only have button-group component in Vue at the moment but we will add it to other Warp libraries.