### PR TITLE
fix(rules): remove bg-transparent and bg-current from deprecated classes

### DIFF
--- a/rules.js
+++ b/rules.js
@@ -36,7 +36,8 @@ const colorRegex = new RegExp("^(text|bg|border|divide)-(" + colors.join("|") + 
 
 export default [
   [colorRegex, ([_]) => emitWarning(_, TYPES.replaced)],
-  [/^(text|bg|border|divide)-(current|transparent|none|white)$/, ([_]) => emitWarning(_, TYPES.replaced)],
+  [/^(text|border|divide)-(current|transparent|none|white)$/, ([_]) => emitWarning(_, TYPES.replaced)],
+  [/^bg-(none|white)$/, ([_]) => emitWarning(_, TYPES.replaced)],
   [/^divide-(dotted|solid|double|dashed)$/, ([_]) => emitWarning(_, TYPES.removed)],
   [/^text-(\d+)$/, ([_]) => emitWarning(_, TYPES.replaced)],
   [/^text-(primary|secondary|danger)$/, ([_]) => emitWarning(_, TYPES.replaced)],

--- a/test/__snapshots__/color.spec.js.snap
+++ b/test/__snapshots__/color.spec.js.snap
@@ -9,22 +9,25 @@ exports[`colors > Emits a warning for color classes with pseudo 2`] = `
 ]
 `;
 
-exports[`colors > Emits a warning if 'text', 'bg', 'border' or 'divide' is used with 'current', 'transparent', 'none' or 'white' 2`] = `
+exports[`colors > Emits a warning if 'bg' is used with 'none' or 'white' 2`] = `
+[
+  "[REPLACED] bg-none",
+  "[REPLACED] bg-white",
+]
+`;
+
+exports[`colors > Emits a warning if 'text', 'border' or 'divide' is used with 'current', 'transparent', 'none' or 'white' 2`] = `
 [
   "[REPLACED] text-current",
-  "[REPLACED] bg-current",
   "[REPLACED] border-current",
   "[REPLACED] divide-current",
   "[REPLACED] text-transparent",
-  "[REPLACED] bg-transparent",
   "[REPLACED] border-transparent",
   "[REPLACED] divide-transparent",
   "[REPLACED] text-none",
-  "[REPLACED] bg-none",
   "[REPLACED] border-none",
   "[REPLACED] divide-none",
   "[REPLACED] text-white",
-  "[REPLACED] bg-white",
   "[REPLACED] border-white",
   "[REPLACED] divide-white",
 ]

--- a/test/color.spec.js
+++ b/test/color.spec.js
@@ -61,12 +61,24 @@ describe("colors", () => {
     expect(warnSpy.calls.flat()).toMatchSnapshot();
   });
 
-  test("Emits a warning if 'text', 'bg', 'border' or 'divide' is used with 'current', 'transparent', 'none' or 'white'", async (t) => {
+  test("Emits a warning if 'text', 'border' or 'divide' is used with 'current', 'transparent', 'none' or 'white'", async (t) => {
     const warnSpy = vi.spyOn(global.console, 'warn')
 
     const classes = ["current", "transparent", "none", "white"].map((color) =>{
-      return ["text", "bg", "border", "divide"].map(el => `${el}-${color}`)
+      return ["text", "border", "divide"].map(el => `${el}-${color}`)
     }).flat()
+
+    const { css } = await t.uno.generate(classes);
+
+    expect(css).toMatchInlineSnapshot('""');
+    expect(warnSpy).toHaveBeenCalledTimes(classes.length);
+    expect(warnSpy.calls.flat()).toMatchSnapshot();
+  });
+
+  test("Emits a warning if 'bg' is used with 'none' or 'white'", async (t) => {
+    const warnSpy = vi.spyOn(global.console, 'warn')
+
+    const classes = ["bg-none", "bg-white"]
 
     const { css } = await t.uno.generate(classes);
 


### PR DESCRIPTION
Those classes are supported in https://github.com/warp-ds/drive/blob/alpha/src/_rules/color.js