### PR TITLE
fix(rules): do not target page-container class

### DIFF
--- a/rules.js
+++ b/rules.js
@@ -60,7 +60,8 @@ export default [
   [/^(link|segment-control|field)(.+)?$/,([_]) => emitWarning(_, TYPES.removed)],
   // old design system classes (troika)
   [/^t-(.+)$/, ([_]) => emitWarning(_, TYPES.removed)],
-  [/^(.+)?container$/, ([_]) => emitWarning('container', TYPES.removed)],
+  // Do not target page-container, but container class with pseudo variants
+  [/^([^page-].+)?container$/, ([_]) => emitWarning('container', TYPES.removed)],
   // miscellaneous
   [/^transition-gpu$/, ([_]) => emitWarning(_, TYPES.removed, "use 'transform-gpu' or 'will-change-*'")],
   [/^fixed-ios-fix$/,([_]) => emitWarning(_, TYPES.removed, "use 'transform translate-z-0'")],

--- a/test/troika.spec.js
+++ b/test/troika.spec.js
@@ -24,6 +24,14 @@ test('prints NO warning for using non deprecated t', async ({ uno }) => {
     expect(warnSpy.calls.flat()).toMatchInlineSnapshot('[]');
 });
 
+test('prints NO warning for using non deprecated page-container', async ({ uno }) => {
+  const warnSpy = vi.spyOn(global.console, 'warn');
+  const classes = ['page-container'];
+  const { css } = await uno.generate(classes);
+  expect(css).toMatchInlineSnapshot('""');
+  expect(warnSpy.calls.flat()).toMatchInlineSnapshot('[]');
+});
+
 test('prints a warning for using deprecated container with pseudo', async ({ uno }) => {
     const warnSpy = vi.spyOn(global.console, 'warn');
     const classes = ['md:container', 'md:t-grid'];


### PR DESCRIPTION
`page-container` class will be supported after all. 
The rule couldn't just include "container" class name, probably because there is a built-in `container` class in unocss, which made that class name not be recognized when combined with `md:`, `sm:` and `lg:` breakpoint variants.