### PR TITLE
fix(package.json): include utils file to package library

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "index.js",
     "rules.js",
     "theme.js",
-    "_pseudo.js"
+    "_pseudo.js",
+    "utils.js"
   ],
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Include the utils file in the exported files, as it was missing and caused errors when using the script. 