### PR TITLE
fix: merge unocss code latest changes, get rid of sortValue function

### DIFF
--- a/_pseudo.js
+++ b/_pseudo.js
@@ -49,10 +49,14 @@ const PseudoClasses = Object.fromEntries([
   ['marker', '::marker'],
   ['file', '::file-selector-button'],
 ].map(key => Array.isArray(key) ? key : [key, `:${key}`]));
-// TODO - rip this out
+
+const PseudoClassesKeys = Object.keys(PseudoClasses)
+
 const PseudoClassesColon = Object.fromEntries([
   ['backdrop', '::backdrop'],
 ].map(key => Array.isArray(key) ? key : [key, `:${key}`]));
+
+const PseudoClassesColonKeys = Object.keys(PseudoClassesColon)
 
 
 const PseudoClassesAndElementsStr = Object.entries(PseudoClasses).map(([key]) => key).join('|');
@@ -66,6 +70,14 @@ export const variantPseudoClassesAndElements = {
     const match = input.match(PseudoClassesAndElementsRE) || input.match(PseudoClassesAndElementsColonRE);
     if (match) {
       const pseudo = PseudoClasses[match[1]] || PseudoClassesColon[match[1]] || `:${match[1]}`;
+
+      // order of pseudo classes
+      let index = PseudoClassesKeys.indexOf(match[1])
+      if (index === -1)
+        index = PseudoClassesColonKeys.indexOf(match[1])
+      if (index === -1)
+        index = undefined
+      
       return {
         matcher: input.slice(match[0].length),
         handle: (input, next) => {
@@ -75,8 +87,9 @@ export const variantPseudoClassesAndElements = {
           return next({
             ...input,
             ...selectors,
-            sort: sortValue(match[1]),
-          });
+            sort: index,
+            noMerge: true,
+        });
         },
       };
     }


### PR DESCRIPTION
In order to be able to process variants we needed to fork unocss code for variants and make some adjustments. `sortValue` function is weird enough not even present in the file. So I removed it now and applied [latest changes from unocss](https://github.com/unocss/unocss/commit/5c681122673ec7f7863e4004c20f390ac206a62b).

I've tried to reproduce the problem locally but was not able so the fix is kinda in the blind but nothing **_should_** break 


Bug is reported here https://sch-chat.slack.com/archives/C04P0GYTHPV/p1686645354378569