### PR TITLE
feat: add warnings for deprecated warp classes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,11 +13,11 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: current
+          node-version: lts/*
       - name: Install pnpm and dependencies
         uses: pnpm/action-setup@v2
         with:
-          version: 7
+          version: 8
           run_install: true
       - name: Release
         env:

--- a/rules.js
+++ b/rules.js
@@ -45,4 +45,6 @@ export default [
   [/^transition-gpu$/, ([_]) => emitWarning(_, TYPES.removed, "use 'transform-gpu' or 'will-change-*'")],
   [/^fixed-ios-fix$/,([_]) => emitWarning(_, TYPES.removed, "use 'transform translate-z-0'")],
   [/^focus-ring$/,  ([_]) => emitWarning(_, TYPES.replaced, "use 'focusable'")],
+  // deprecated Warp classes
+  [/^s-(.+)-default$/, ([_]) => emitWarning(_, TYPES.deprecated, `use '${_.replace('-default', '')}'`)]
 ]

--- a/rules.js
+++ b/rules.js
@@ -46,5 +46,8 @@ export default [
   [/^fixed-ios-fix$/,([_]) => emitWarning(_, TYPES.removed, "use 'transform translate-z-0'")],
   [/^focus-ring$/,  ([_]) => emitWarning(_, TYPES.replaced, "use 'focusable'")],
   // deprecated Warp classes
-  [/^s-(.+)-default$/, ([_]) => emitWarning(_, TYPES.deprecated, `use '${_.replace('-default', '')}'`)]
+  [/^s-(.+)-default$/, ([_]) => emitWarning(_, TYPES.deprecated, `use '${_.replace('-default', '')}'`)],
+  [/^color-focused?$/, ([_]) => emitWarning(_, TYPES.deprecated, "use 's-focused'")],
+  [/^color-background(-.+)?$/, ([_]) => emitWarning(_, TYPES.deprecated, COLOR_MESSAGES.background)],
+  [/^color-text(-.+)?$/, ([_]) => emitWarning(_, TYPES.deprecated, COLOR_MESSAGES.text)],
 ]

--- a/rules.js
+++ b/rules.js
@@ -47,6 +47,8 @@ export default [
   [/^focus-ring$/,  ([_]) => emitWarning(_, TYPES.replaced, "use 'focusable'")],
   // deprecated Warp classes
   [/^s-(.+)-default$/, ([_]) => emitWarning(_, TYPES.deprecated, `use '${_.replace('-default', '')}'`)],
+  [/^s-text-link-hover(-active)?$/, ([_]) => emitWarning(_, TYPES.deprecated, `use 's-text-link'`)],
+  [/^s-(.+)-active-hover$/, ([_]) => emitWarning(_, TYPES.deprecated, `use classes with '-selected-hover' if available'`)],
   [/^color-focused?$/, ([_]) => emitWarning(_, TYPES.deprecated, "use 's-focused'")],
   [/^color-background(-.+)?$/, ([_]) => emitWarning(_, TYPES.deprecated, COLOR_MESSAGES.background)],
   [/^color-text(-.+)?$/, ([_]) => emitWarning(_, TYPES.deprecated, COLOR_MESSAGES.text)],

--- a/test/__snapshots__/warp-deprecated.spec.js.snap
+++ b/test/__snapshots__/warp-deprecated.spec.js.snap
@@ -1,5 +1,24 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`deprecated warp classes > Emits a warning if color classes without s- suffix are found 2`] = `
+[
+  "[93m[DEPRECATED][0m color-focused -> use 's-focused'",
+  "[93m[DEPRECATED][0m color-background -> see https://warp-ds.github.io/css-docs/background-color to find suitable semantic replacement",
+  "[93m[DEPRECATED][0m color-background-subtle -> see https://warp-ds.github.io/css-docs/background-color to find suitable semantic replacement",
+  "[93m[DEPRECATED][0m color-background-interactive -> see https://warp-ds.github.io/css-docs/background-color to find suitable semantic replacement",
+  "[93m[DEPRECATED][0m color-background-interactive-hover -> see https://warp-ds.github.io/css-docs/background-color to find suitable semantic replacement",
+  "[93m[DEPRECATED][0m color-background-interactive-selected -> see https://warp-ds.github.io/css-docs/background-color to find suitable semantic replacement",
+  "[93m[DEPRECATED][0m color-text -> see https://warp-ds.github.io/css-docs/text-color to find suitable semantic replacement",
+  "[93m[DEPRECATED][0m color-text-subtle -> see https://warp-ds.github.io/css-docs/text-color to find suitable semantic replacement",
+  "[93m[DEPRECATED][0m color-text-placeholder -> see https://warp-ds.github.io/css-docs/text-color to find suitable semantic replacement",
+  "[93m[DEPRECATED][0m color-text-inverted -> see https://warp-ds.github.io/css-docs/text-color to find suitable semantic replacement",
+  "[93m[DEPRECATED][0m color-text-inverted-subtle -> see https://warp-ds.github.io/css-docs/text-color to find suitable semantic replacement",
+  "[93m[DEPRECATED][0m color-text-link -> see https://warp-ds.github.io/css-docs/text-color to find suitable semantic replacement",
+  "[93m[DEPRECATED][0m color-text-link-hover -> see https://warp-ds.github.io/css-docs/text-color to find suitable semantic replacement",
+  "[93m[DEPRECATED][0m color-text-link-visited -> see https://warp-ds.github.io/css-docs/text-color to find suitable semantic replacement",
+]
+`;
+
 exports[`deprecated warp classes > Emits a warning if semantic color classes used with -default suffix are found 2`] = `
 [
   "[93m[DEPRECATED][0m s-color-background-default -> use 's-color-background'",

--- a/test/__snapshots__/warp-deprecated.spec.js.snap
+++ b/test/__snapshots__/warp-deprecated.spec.js.snap
@@ -1,0 +1,27 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`deprecated warp classes > Emits a warning if semantic color classes used with -default suffix are found 2`] = `
+[
+  "[93m[DEPRECATED][0m s-color-background-default -> use 's-color-background'",
+  "[93m[DEPRECATED][0m s-color-background-subtle-default -> use 's-color-background-subtle'",
+  "[93m[DEPRECATED][0m s-color-background-primary-default -> use 's-color-background-primary'",
+  "[93m[DEPRECATED][0m s-color-background-positive-default -> use 's-color-background-positive'",
+  "[93m[DEPRECATED][0m s-color-background-negative-default -> use 's-color-background-negative'",
+  "[93m[DEPRECATED][0m s-color-background-warning-default -> use 's-color-background-warning'",
+  "[93m[DEPRECATED][0m s-color-background-info-default -> use 's-color-background-info'",
+  "[93m[DEPRECATED][0m s-color-border-default -> use 's-color-border'",
+  "[93m[DEPRECATED][0m s-color-border-primary-default -> use 's-color-border-primary'",
+  "[93m[DEPRECATED][0m s-color-border-primary-subtle-default -> use 's-color-border-primary-subtle'",
+  "[93m[DEPRECATED][0m s-color-border-positive-default -> use 's-color-border-positive'",
+  "[93m[DEPRECATED][0m s-color-border-positive-subtle-default -> use 's-color-border-positive-subtle'",
+  "[93m[DEPRECATED][0m s-color-border-negative-default -> use 's-color-border-negative'",
+  "[93m[DEPRECATED][0m s-color-border-negative-subtle-default -> use 's-color-border-negative-subtle'",
+  "[93m[DEPRECATED][0m s-color-border-warning-default -> use 's-color-border-warning'",
+  "[93m[DEPRECATED][0m s-color-border-warning-subtle-default -> use 's-color-border-warning-subtle'",
+  "[93m[DEPRECATED][0m s-color-border-info-default -> use 's-color-border-info'",
+  "[93m[DEPRECATED][0m s-color-border-info-subtle-default -> use 's-color-border-info-subtle'",
+  "[93m[DEPRECATED][0m s-color-icon-default -> use 's-color-icon'",
+  "[93m[DEPRECATED][0m s-color-icon-subtle-default -> use 's-color-icon-subtle'",
+  "[93m[DEPRECATED][0m s-color-text-default -> use 's-color-text'",
+]
+`;

--- a/test/__snapshots__/warp-deprecated.spec.js.snap
+++ b/test/__snapshots__/warp-deprecated.spec.js.snap
@@ -1,5 +1,12 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`deprecated warp classes > Emits a warning if 's-text-link-hover' or 's-text-link-hover-active' are found 2`] = `
+[
+  "[93m[DEPRECATED][0m s-text-link-hover -> use 's-text-link'",
+  "[93m[DEPRECATED][0m s-text-link-hover-active -> use 's-text-link'",
+]
+`;
+
 exports[`deprecated warp classes > Emits a warning if color classes without s- suffix are found 2`] = `
 [
   "[93m[DEPRECATED][0m color-focused -> use 's-focused'",
@@ -16,6 +23,29 @@ exports[`deprecated warp classes > Emits a warning if color classes without s- s
   "[93m[DEPRECATED][0m color-text-link -> see https://warp-ds.github.io/css-docs/text-color to find suitable semantic replacement",
   "[93m[DEPRECATED][0m color-text-link-hover -> see https://warp-ds.github.io/css-docs/text-color to find suitable semantic replacement",
   "[93m[DEPRECATED][0m color-text-link-visited -> see https://warp-ds.github.io/css-docs/text-color to find suitable semantic replacement",
+]
+`;
+
+exports[`deprecated warp classes > Emits a warning if semantic color classes used with -active-hover suffix are found 2`] = `
+[
+  "[93m[DEPRECATED][0m s-bg-active-hover -> use classes with '-selected-hover' if available'",
+  "[93m[DEPRECATED][0m s-bg-subtle-active-hover -> use classes with '-selected-hover' if available'",
+  "[93m[DEPRECATED][0m s-bg-primary-active-hover -> use classes with '-selected-hover' if available'",
+  "[93m[DEPRECATED][0m s-bg-negative-active-hover -> use classes with '-selected-hover' if available'",
+  "[93m[DEPRECATED][0m s-bg-positive-active-hover -> use classes with '-selected-hover' if available'",
+  "[93m[DEPRECATED][0m s-bg-warning-active-hover -> use classes with '-selected-hover' if available'",
+  "[93m[DEPRECATED][0m s-bg-info-active-hover -> use classes with '-selected-hover' if available'",
+  "[93m[DEPRECATED][0m s-bg-info-subtle-active-hover -> use classes with '-selected-hover' if available'",
+  "[93m[DEPRECATED][0m s-border-active-hover -> use classes with '-selected-hover' if available'",
+  "[93m[DEPRECATED][0m s-border-subtle-active-hover -> use classes with '-selected-hover' if available'",
+  "[93m[DEPRECATED][0m s-border-primary-active-hover -> use classes with '-selected-hover' if available'",
+  "[93m[DEPRECATED][0m s-border-negative-active-hover -> use classes with '-selected-hover' if available'",
+  "[93m[DEPRECATED][0m s-border-positive-active-hover -> use classes with '-selected-hover' if available'",
+  "[93m[DEPRECATED][0m s-border-warning-active-hover -> use classes with '-selected-hover' if available'",
+  "[93m[DEPRECATED][0m s-border-info-active-hover -> use classes with '-selected-hover' if available'",
+  "[93m[DEPRECATED][0m s-border-info-subtle-active-hover -> use classes with '-selected-hover' if available'",
+  "[93m[DEPRECATED][0m s-icon-active-hover -> use classes with '-selected-hover' if available'",
+  "[93m[DEPRECATED][0m s-icon-subtle-active-hover -> use classes with '-selected-hover' if available'",
 ]
 `;
 

--- a/test/warp-deprecated.spec.js
+++ b/test/warp-deprecated.spec.js
@@ -1,0 +1,41 @@
+import { setup } from "./_helpers.js";
+import { describe, expect, test, vi } from "vitest";
+
+setup();
+
+
+describe("deprecated warp classes", () => {
+  test("Emits a warning if semantic color classes used with -default suffix are found", async (t) => {
+    const warnSpy = vi.spyOn(global.console, 'warn')
+
+    const classes = [
+      's-color-background-default',
+      's-color-background-subtle-default',
+      's-color-background-primary-default',
+      's-color-background-positive-default',
+      's-color-background-negative-default',
+      's-color-background-warning-default',
+      's-color-background-info-default',
+      's-color-border-default',
+      's-color-border-primary-default',
+      's-color-border-primary-subtle-default',
+      's-color-border-positive-default',
+      's-color-border-positive-subtle-default',
+      's-color-border-negative-default',
+      's-color-border-negative-subtle-default',
+      's-color-border-warning-default',
+      's-color-border-warning-subtle-default',
+      's-color-border-info-default',
+      's-color-border-info-subtle-default',
+      's-color-icon-default',
+      's-color-icon-subtle-default',
+      's-color-text-default'
+    ]
+
+    const { css } = await t.uno.generate(classes);
+
+    expect(css).toMatchInlineSnapshot('""');
+    expect(warnSpy).toHaveBeenCalledTimes(classes.length);
+    expect(warnSpy.calls.flat()).toMatchSnapshot();
+  });
+})

--- a/test/warp-deprecated.spec.js
+++ b/test/warp-deprecated.spec.js
@@ -38,4 +38,30 @@ describe("deprecated warp classes", () => {
     expect(warnSpy).toHaveBeenCalledTimes(classes.length);
     expect(warnSpy.calls.flat()).toMatchSnapshot();
   });
+
+  test("Emits a warning if color classes without s- suffix are found", async (t) => {
+    const warnSpy = vi.spyOn(global.console, 'warn')
+
+    const classes = [
+    'color-focused',
+    'color-background',
+    'color-background-subtle',
+    'color-background-interactive',
+    'color-background-interactive-hover',
+    'color-background-interactive-selected',
+    'color-text',
+    'color-text-subtle',
+    'color-text-placeholder',
+    'color-text-inverted',
+    'color-text-inverted-subtle',
+    'color-text-link',
+    'color-text-link-hover',
+    'color-text-link-visited',]
+
+    const { css } = await t.uno.generate(classes);
+
+    expect(css).toMatchInlineSnapshot('""');
+    expect(warnSpy).toHaveBeenCalledTimes(classes.length);
+    expect(warnSpy.calls.flat()).toMatchSnapshot();
+  });
 })

--- a/test/warp-deprecated.spec.js
+++ b/test/warp-deprecated.spec.js
@@ -39,6 +39,52 @@ describe("deprecated warp classes", () => {
     expect(warnSpy.calls.flat()).toMatchSnapshot();
   });
 
+  test("Emits a warning if semantic color classes used with -active-hover suffix are found", async (t) => {
+    const warnSpy = vi.spyOn(global.console, 'warn')
+
+    const classes = [
+      's-bg-active-hover',
+      's-bg-subtle-active-hover',
+      's-bg-primary-active-hover',
+      's-bg-negative-active-hover',
+      's-bg-positive-active-hover',
+      's-bg-warning-active-hover',
+      's-bg-info-active-hover',
+      's-bg-info-subtle-active-hover',
+      's-border-active-hover',
+      's-border-subtle-active-hover',
+      's-border-primary-active-hover',
+      's-border-negative-active-hover',
+      's-border-positive-active-hover',
+      's-border-warning-active-hover',
+      's-border-info-active-hover',
+      's-border-info-subtle-active-hover',
+      's-icon-active-hover',
+      's-icon-subtle-active-hover'
+    ]
+
+    const { css } = await t.uno.generate(classes);
+
+    expect(css).toMatchInlineSnapshot('""');
+    expect(warnSpy).toHaveBeenCalledTimes(classes.length);
+    expect(warnSpy.calls.flat()).toMatchSnapshot();
+  });
+
+  test("Emits a warning if 's-text-link-hover' or 's-text-link-hover-active' are found", async (t) => {
+    const warnSpy = vi.spyOn(global.console, 'warn')
+
+    const classes = [
+      's-text-link-hover',
+      's-text-link-hover-active',
+    ]
+
+    const { css } = await t.uno.generate(classes);
+
+    expect(css).toMatchInlineSnapshot('""');
+    expect(warnSpy).toHaveBeenCalledTimes(classes.length);
+    expect(warnSpy.calls.flat()).toMatchSnapshot();
+  });
+
   test("Emits a warning if color classes without s- suffix are found", async (t) => {
     const warnSpy = vi.spyOn(global.console, 'warn')
 

--- a/utils.js
+++ b/utils.js
@@ -19,7 +19,8 @@ export const COLOR_MESSAGES = {
 
 export const TYPES = {
   replaced: "[REPLACED]",
-  removed: "[REMOVED]"
+  removed: "[REMOVED]",
+  deprecated: "[DEPRECATED]",
 };
 
 const CLASS_MAP = {


### PR DESCRIPTION
Suggested replacements for the deprecated classes require the tokens from `@warp-ds/css@1.0.0` to be available.

Rules added are based on classes listed in [warp-ds/css/tokens/finn.no/deprecated.yml](https://github.com/warp-ds/css/blob/alpha/tokens/finn.no/deprecated.yml)